### PR TITLE
💫 Add React View Transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,44 +1,6 @@
 @layer base, components, utilities;
 
 @layer base {
-  @keyframes fade-in {
-    from {
-      opacity: 0;
-    }
-  }
-
-  @keyframes fade-out {
-    to {
-      opacity: 0;
-    }
-  }
-
-  @keyframes slide-from-right {
-    from {
-      translate: 30px;
-    }
-  }
-
-  @keyframes slide-to-left {
-    to {
-      translate: -30px;
-    }
-  }
-
-  ::view-transition-old(root) {
-    @media (prefers-reduced-motion: no-preference) {
-      animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
-        300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
-    }
-  }
-
-  ::view-transition-new(root) {
-    @media (prefers-reduced-motion: no-preference) {
-      animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
-        300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
-    }
-  }
-
   :root {
     --color-mine-shaft: oklch(26% 0 0deg);
     --color-cod-gray: oklch(18% 0 0deg);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,0 @@
-import { ViewTransitions } from "next-view-transitions";
-
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <ViewTransitions>{children}</ViewTransitions>;
-}

--- a/components/header.module.css
+++ b/components/header.module.css
@@ -15,7 +15,6 @@
       overflow-y: auto;
       scrollbar-color: var(--color-scrollbar) #0000;
       scrollbar-width: thin;
-      view-transition-name: header;
     }
 
     h1 {

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -1,4 +1,42 @@
 @layer components {
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+  }
+
+  @keyframes fade-out {
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes slide-from-right {
+    from {
+      translate: 30px;
+    }
+  }
+
+  @keyframes slide-to-left {
+    to {
+      translate: -30px;
+    }
+  }
+
+  ::view-transition-old(.slide-in) {
+    @media (prefers-reduced-motion: no-preference) {
+      animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+        300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+    }
+  }
+
+  ::view-transition-new(.slide-in) {
+    @media (prefers-reduced-motion: no-preference) {
+      animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+        300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+    }
+  }
+
   .root {
     display: grid;
     grid-template-areas: "alert" "header" "content" "footer";

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,4 +1,5 @@
 import { draftMode } from "next/headers";
+import { unstable_ViewTransition as ViewTransition } from "react";
 import Alert from "./alert";
 import Footer from "./footer";
 import Header from "./header";
@@ -13,11 +14,15 @@ export default async function Layout({
   const { isEnabled } = await draftMode();
 
   return (
-    <div className={styles.root}>
-      {isEnabled && <Alert />}
-      <Header page={page} />
-      <main className={styles.content}>{children}</main>
-      <Footer />
-    </div>
+    <ViewTransition default={styles["slide-in"]}>
+      <div className={styles.root}>
+        {isEnabled && <Alert />}
+        <ViewTransition name="header">
+          <Header page={page} />
+        </ViewTransition>
+        <main className={styles.content}>{children}</main>
+        <Footer />
+      </div>
+    </ViewTransition>
   );
 }

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Link as ViewTransitionsLink } from "next-view-transitions";
+import NextLink from "next/link";
 import { useIntl } from "react-intl";
 import { LOCALES } from "@/lib/constants";
 import styles from "./link.module.css";
@@ -9,7 +9,7 @@ export default function Link({
   href,
   underline,
   ...props
-}: React.ComponentPropsWithoutRef<typeof ViewTransitionsLink> & {
+}: React.ComponentPropsWithoutRef<typeof NextLink> & {
   underline?: "hover" | boolean;
 }) {
   const { locale } = useIntl();
@@ -23,7 +23,7 @@ export default function Link({
   }
 
   return (
-    <ViewTransitionsLink
+    <NextLink
       className={styles.root}
       href={href}
       data-underline={underline || undefined}

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: true,
     useLightningcss: true,
+    viewTransition: true,
   },
   async redirects() {
     return [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "motion": "12.9.2",
     "negotiator": "^1.0.0",
     "next": "^15.3.1",
-    "next-view-transitions": "^0.3.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-intl": "^7.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       next:
         specifier: ^15.3.1
         version: 15.3.1(@babel/core@7.26.7)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      next-view-transitions:
-        specifier: ^0.3.4
-        version: 0.3.4(next@15.3.1(@babel/core@7.26.7)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1788,13 +1785,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  next-view-transitions@0.3.4:
-    resolution: {integrity: sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ==}
-    peerDependencies:
-      next: '>=14.0.0'
-      react: ^18.2.0
-      react-dom: ^18.2.0
 
   next@15.3.1:
     resolution: {integrity: sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==}
@@ -4134,12 +4124,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
-
-  next-view-transitions@0.3.4(next@15.3.1(@babel/core@7.26.7)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      next: 15.3.1(@babel/core@7.26.7)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   next@15.3.1(@babel/core@7.26.7)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
This pull request refactors the implementation of view transitions by replacing the `next-view-transitions` library with the experimental `viewTransition` feature in Next.js. It also introduces changes to CSS animations and updates the project dependencies accordingly.

### Transition Implementation Refactor:

* Removed the `next-view-transitions` library and replaced it with the experimental `viewTransition` feature in Next.js, enabling native support for view transitions. (`package.json`, `pnpm-lock.yaml`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL47-L49) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1792-L1798) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4138-L4143)
* Updated `components/layout.tsx` to use `unstable_ViewTransition` from React for wrapping layout elements, ensuring smooth transitions. [[1]](diffhunk://#diff-7d00022830ba75a86c65e4c942eb140aecdcf1492ba7ba3ed0f0dcee9e6a056eR2) [[2]](diffhunk://#diff-7d00022830ba75a86c65e4c942eb140aecdcf1492ba7ba3ed0f0dcee9e6a056eR17-R26)
* Replaced `ViewTransitionsLink` with `NextLink` in `components/link.tsx` to align with the new transition implementation. [[1]](diffhunk://#diff-2f946f967e566b0428ebae75bd3df53347b07d4722a946d975c19c3af101e442L3-R3) [[2]](diffhunk://#diff-2f946f967e566b0428ebae75bd3df53347b07d4722a946d975c19c3af101e442L12-R12) [[3]](diffhunk://#diff-2f946f967e566b0428ebae75bd3df53347b07d4722a946d975c19c3af101e442L26-R26)

### CSS Animation Updates:

* Moved keyframe animations (`fade-in`, `fade-out`, `slide-from-right`, `slide-to-left`) and transition styles from `app/globals.css` to `components/layout.module.css` for better scoping and maintainability. [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L4-L41) [[2]](diffhunk://#diff-5ad45f42ad9e3e7afc51ec8eaa57719449fe3e45fb82b72446788359f481c9beR2-R39)
* Removed the `view-transition-name` property from `components/header.module.css` as it is no longer required with the new implementation.

### Next.js Configuration:

* Enabled the experimental `viewTransition` feature in `next.config.ts` to support the native view transition API.